### PR TITLE
Adding configparser as a required module

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ coveralls = "*"
 
 [packages]
 "boto3" = "*"
+"configparser" = "*"
 
 [requires]
 python_version = "3.6"


### PR DESCRIPTION
This comes up as a missing module during a fresh install.